### PR TITLE
docs: add terragrunt example

### DIFF
--- a/.azure/pipelines/examples-test.yml
+++ b/.azure/pipelines/examples-test.yml
@@ -20,10 +20,10 @@ jobs:
           --out-file=/tmp/infracost.json
         displayName: Run Infracost
         env:
-          DEV_AWS_ACCESS_KEY_ID: $(DEV_AWS_ACCESS_KEY_ID)
-          DEV_AWS_SECRET_ACCESS_KEY: $(DEV_AWS_SECRET_ACCESS_KEY)
-          PROD_AWS_ACCESS_KEY_ID: $(PROD_AWS_ACCESS_KEY_ID)
-          PROD_AWS_SECRET_ACCESS_KEY: $(PROD_AWS_SECRET_ACCESS_KEY)
+          DEV_AWS_ACCESS_KEY_ID: $(exampleDevAwsAccessKeyId)
+          DEV_AWS_SECRET_ACCESS_KEY: $(exampleDevAwsSecretAccessKey)
+          PROD_AWS_ACCESS_KEY_ID: $(exampleProdAwsAccessKeyId)
+          PROD_AWS_SECRET_ACCESS_KEY: $(exampleProdAwsSecretAccessKey)
       - bash: >-
           infracost output --path=/tmp/infracost.json
           --format=azure-repos-comment --show-skipped
@@ -40,12 +40,12 @@ jobs:
     strategy:
       matrix:
         dev:
-          AWS_ACCESS_KEY_ID: $(DEV_AWS_ACCESS_KEY_ID)
-          AWS_SECRET_ACCESS_KEY: $(DEV_AWS_SECRET_ACCESS_KEY)
+          AWS_ACCESS_KEY_ID: $(exampleDevAwsAccessKeyId)
+          AWS_SECRET_ACCESS_KEY: $(exampleDevAwsSecretAccessKey)
           DIR: dev
         prod:
-          AWS_ACCESS_KEY_ID: $(PROD_AWS_ACCESS_KEY_ID)
-          AWS_SECRET_ACCESS_KEY: $(PROD_AWS_SECRET_ACCESS_KEY)
+          AWS_ACCESS_KEY_ID: $(exampleProdAwsAccessKeyId)
+          AWS_SECRET_ACCESS_KEY: $(exampleProdAwsSecretAccessKey)
           DIR: prod
       maxParallel: 2
     steps:
@@ -155,4 +155,42 @@ jobs:
       - bash: >-
           diff ./testdata/terraform_plan_json_comment_golden.md
           /tmp/infracost_comment.md
+        displayName: Check the comment
+  - job: terragrunt
+    displayName: Terragrunt
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+      - task: TerraformInstaller@0
+        displayName: Install Terraform
+      - bash: >
+          INSTALL_LOCATION="$(Build.SourcesDirectory)/bin"
+
+          mkdir -p ${INSTALL_LOCATION}
+
+
+          curl -sL
+          "https://github.com/gruntwork-io/terragrunt/releases/latest/download/terragrunt_linux_amd64"
+          > ${INSTALL_LOCATION}/terragrunt
+
+          chmod +x ${INSTALL_LOCATION}/terragrunt
+
+
+          echo "##vso[task.setvariable
+          variable=PATH;]$(PATH):${INSTALL_LOCATION}"
+        displayName: Setup Terragrunt
+      - task: InfracostSetup@0
+        displayName: Setup Infracost
+        inputs:
+          apiKey: $(API_KEY)
+      - bash: >-
+          infracost breakdown --path=examples/terragrunt/code --format=json
+          --out-file=/tmp/infracost.json
+        displayName: Run Infracost
+      - bash: >-
+          infracost output --path=/tmp/infracost.json
+          --format=azure-repos-comment --show-skipped
+          --out-file=/tmp/infracost_comment.md
+        displayName: Generate Infracost comment
+      - bash: diff ./testdata/terragrunt_comment_golden.md /tmp/infracost_comment.md
         displayName: Check the comment

--- a/examples/multi-project/README.md
+++ b/examples/multi-project/README.md
@@ -13,10 +13,6 @@ pr:
 
 variables:
   API_KEY: $(apiKey)
-  DEV_AWS_ACCESS_KEY_ID: $(exampleDevAwsAccessKeyId)
-  DEV_AWS_SECRET_ACCESS_KEY: $(exampleDevAwsSecretAccessKey)
-  PROD_AWS_ACCESS_KEY_ID: $(exampleProdAwsAccessKeyId)
-  PROD_AWS_SECRET_ACCESS_KEY: $(exampleProdAwsSecretAccessKey)
   
 jobs:
   - job: multi_project_config_file
@@ -37,16 +33,16 @@ jobs:
         displayName: Run Infracost
         env:
           # IMPORTANT: add any required secrets to setup cloud credentials so Terraform can run
-          DEV_AWS_ACCESS_KEY_ID: $(DEV_AWS_ACCESS_KEY_ID)
-          DEV_AWS_SECRET_ACCESS_KEY: $(DEV_AWS_SECRET_ACCESS_KEY)
-          PROD_AWS_ACCESS_KEY_ID: $(PROD_AWS_ACCESS_KEY_ID)
-          PROD_AWS_SECRET_ACCESS_KEY: $(PROD_AWS_SECRET_ACCESS_KEY)
+          DEV_AWS_ACCESS_KEY_ID: $(exampleDevAwsAccessKeyId)
+          DEV_AWS_SECRET_ACCESS_KEY: $(exampleDevAwsSecretAccessKey)
+          PROD_AWS_ACCESS_KEY_ID: $(exampleProdAwsAccessKeyId)
+          PROD_AWS_SECRET_ACCESS_KEY: $(exampleProdAwsSecretAccessKey)
 
       - task: InfracostComment@0
         displayName: Post the comment
         inputs:
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/comment for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#comment-options for other options
 ```
 [//]: <> (END EXAMPLE)
 
@@ -70,12 +66,12 @@ jobs:
     strategy:
       matrix:
         dev:
-          AWS_ACCESS_KEY_ID: $(DEV_AWS_ACCESS_KEY_ID)
-          AWS_SECRET_ACCESS_KEY: $(DEV_AWS_SECRET_ACCESS_KEY) 
+          AWS_ACCESS_KEY_ID: $(exampleDevAwsAccessKeyId)
+          AWS_SECRET_ACCESS_KEY: $(exampleDevAwsSecretAccessKey) 
           DIR: 'dev'
         prod:
-          AWS_ACCESS_KEY_ID: $(PROD_AWS_ACCESS_KEY_ID)
-          AWS_SECRET_ACCESS_KEY: $(PROD_AWS_SECRET_ACCESS_KEY)
+          AWS_ACCESS_KEY_ID: $(exampleProdAwsAccessKeyId)
+          AWS_SECRET_ACCESS_KEY: $(exampleProdAwsSecretAccessKey)
           DIR: 'prod'
       maxParallel: 2
 
@@ -128,6 +124,6 @@ jobs:
         displayName: Post the comment
         inputs:
           path: /tmp/infracost_combined.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/comment for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#comment-options for other options
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/terraform-plan-json/README.md
+++ b/examples/terraform-plan-json/README.md
@@ -29,6 +29,6 @@ jobs:
         displayName: Post the comment
         inputs:
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/comment for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#comment-options for other options
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/terragrunt/README.md
+++ b/examples/terragrunt/README.md
@@ -1,0 +1,48 @@
+# Terragrunt
+
+This example shows how to run Infracost Azure Devops tasks with Terragrunt.
+
+[//]: <> (BEGIN EXAMPLE)
+```yml
+pr:
+  - master
+
+variables:
+  API_KEY: $(apiKey)
+  
+jobs:
+  - job: terragrunt
+    displayName: Terragrunt
+    pool: 
+      vmImage: ubuntu-latest
+
+    steps:
+      - task: TerraformInstaller@0
+        displayName: Install Terraform
+
+      - bash: |
+          INSTALL_LOCATION="$(Build.SourcesDirectory)/bin"
+          mkdir -p ${INSTALL_LOCATION}
+
+          curl -sL "https://github.com/gruntwork-io/terragrunt/releases/latest/download/terragrunt_linux_amd64" > ${INSTALL_LOCATION}/terragrunt
+          chmod +x ${INSTALL_LOCATION}/terragrunt
+
+          echo "##vso[task.setvariable variable=PATH;]$(PATH):${INSTALL_LOCATION}"
+
+        displayName: Setup Terragrunt
+
+      - task: InfracostSetup@0
+        displayName: Setup Infracost
+        inputs:
+          apiKey: $(API_KEY)
+
+      - bash: infracost breakdown --path=examples/terragrunt/code --format=json --out-file=/tmp/infracost.json
+        displayName: Run Infracost
+        
+      - task: InfracostComment@0
+        displayName: Post the comment
+        inputs:
+          path: /tmp/infracost.json
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#comment-options for other options
+```
+[//]: <> (END EXAMPLE)

--- a/examples/terragrunt/code/dev/terragrunt.hcl
+++ b/examples/terragrunt/code/dev/terragrunt.hcl
@@ -1,0 +1,16 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "..//modules/example"
+}
+
+inputs = {
+  instance_type = "t2.micro"
+  root_block_device_volume_size = 50
+  block_device_volume_size = 100
+  block_device_iops = 400
+  
+  hello_world_function_memory_size = 512
+}

--- a/examples/terragrunt/code/modules/example/main.tf
+++ b/examples/terragrunt/code/modules/example/main.tf
@@ -1,0 +1,48 @@
+variable "instance_type" {
+  description = "The EC2 instance type for the web app"
+  type        = string
+}
+
+variable "root_block_device_volume_size" {
+  description = "The size of the root block device volume for the web app EC2 instance"
+  type        = number
+}
+
+variable "block_device_volume_size" {
+  description = "The size of the block device volume for the web app EC2 instance"
+  type        = number
+}
+
+variable "block_device_iops" {
+  description = "The number of IOPS for the block device for the web app EC2 instance"
+  type        = number
+}
+
+variable "hello_world_function_memory_size" {
+  description = "The memory to allocate to the hello world Lambda function"
+  type        = number
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_type
+
+  root_block_device {
+    volume_size = var.root_block_device_volume_size
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = var.block_device_volume_size
+    iops        = var.block_device_iops
+  }
+}
+
+resource "aws_lambda_function" "hello_world" {
+  function_name = "hello_world"
+  role          = "arn:aws:lambda:us-east-1:account-id:resource-id"
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
+  memory_size   = var.hello_world_function_memory_size
+}

--- a/examples/terragrunt/code/prod/terragrunt.hcl
+++ b/examples/terragrunt/code/prod/terragrunt.hcl
@@ -1,0 +1,16 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "..//modules/example"
+}
+
+inputs = {
+  instance_type = "m5.4xlarge"
+  root_block_device_volume_size = 100
+  block_device_volume_size = 1000
+  block_device_iops = 800
+  
+  hello_world_function_memory_size = 1024
+}

--- a/examples/terragrunt/code/terragrunt.hcl
+++ b/examples/terragrunt/code/terragrunt.hcl
@@ -1,0 +1,18 @@
+locals {
+  aws_region = "us-east-1" # <<<<< Try changing this to eu-west-1 to compare the costs
+}
+
+# Generate an AWS provider block
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "aws" {
+  region                      = "${local.aws_region}"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+EOF
+}

--- a/testdata/terragrunt_comment_golden.md
+++ b/testdata/terragrunt_comment_golden.md
@@ -1,0 +1,113 @@
+
+💰 Infracost estimate: **monthly cost will increase by $800 📈**
+<table>
+  <thead>
+    <td>Project</td>
+    <td>Previous</td>
+    <td>New</td>
+    <td>Diff</td>
+  </thead>
+  <tbody>
+    <tr>
+      <td>infracost/infracost-azure-devops/examples/terragrunt/code/dev</td>
+      <td align="right">$0</td>
+      <td align="right">$51.97</td>
+      <td>+$51.97</td>
+    </tr>
+    <tr>
+      <td>infracost/infracost-azure-devops/examples/terragrunt/code/prod</td>
+      <td align="right">$0</td>
+      <td align="right">$748</td>
+      <td>+$748</td>
+    </tr>
+    <tr>
+      <td>All projects</td>
+      <td align="right">$0</td>
+      <td align="right">$800</td>
+      <td>+$800</td>
+    </tr>
+  </tbody>
+</table>
+
+<details>
+<summary><strong>Infracost output</strong></summary>
+
+```
+Project: infracost/infracost-azure-devops/examples/terragrunt/code/dev
+
++ aws_instance.web_app
+  +$51.97
+
+    + Instance usage (Linux/UNIX, on-demand, t2.micro)
+      +$8.47
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$5.00
+
+    + ebs_block_device[0]
+    
+        + Storage (provisioned IOPS SSD, io1)
+          +$12.50
+    
+        + Provisioned IOPS
+          +$26.00
+
++ aws_lambda_function.hello_world
+  Monthly cost depends on usage
+
+    + Requests
+      Monthly cost depends on usage
+        +$0.20 per 1M requests
+
+    + Duration
+      Monthly cost depends on usage
+        +$0.0000166667 per GB-seconds
+
+Monthly cost change for infracost/infracost-azure-devops/examples/terragrunt/code/dev
+Amount:  +$51.97 ($0.00 → $51.97)
+
+──────────────────────────────────
+Project: infracost/infracost-azure-devops/examples/terragrunt/code/prod
+
++ aws_instance.web_app
+  +$748
+
+    + Instance usage (Linux/UNIX, on-demand, m5.4xlarge)
+      +$561
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$10.00
+
+    + ebs_block_device[0]
+    
+        + Storage (provisioned IOPS SSD, io1)
+          +$125
+    
+        + Provisioned IOPS
+          +$52.00
+
++ aws_lambda_function.hello_world
+  Monthly cost depends on usage
+
+    + Requests
+      Monthly cost depends on usage
+        +$0.20 per 1M requests
+
+    + Duration
+      Monthly cost depends on usage
+        +$0.0000166667 per GB-seconds
+
+Monthly cost change for infracost/infracost-azure-devops/examples/terragrunt/code/prod
+Amount:  +$748 ($0.00 → $748)
+
+──────────────────────────────────
+Key: ~ changed, + added, - removed
+
+4 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+```
+</details>


### PR DESCRIPTION
Adds support for terragrunt pipeline example. Currently installs terragrunt with bash as terragrunt task looks relatively unused.