### PR TITLE
docs: add publisher links to extension json

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -61,7 +61,13 @@
       "uri": "https://github.com/infracost/infracost-azure-devops/issues"
     },
     "support": {
-      "uri": "mailto:hello@infracost.io"
+      "uri": "https://www.infracost.io/docs/support/"
+    },
+    "license": {
+      "uri": "https://github.com/infracost/infracost-azure-devops/blob/master/LICENSE"
+    },
+    "privacypolicy": {
+      "uri": "https://www.infracost.io/docs/privacy-policy/"
     }
   },
   "repository": {


### PR DESCRIPTION
I've altered the vss-extension.json to include links recommended by the [top publisher spec](https://docs.microsoft.com/en-us/azure/devops/extend/publish/publicize?view=azure-devops#top-publisher).

I've also altered the `support` link to point to the issues url, as mailto is discouraged.