### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Infracost Azure DevOps integration
+# Infracost Azure Pipelines integration
 
-This project provides an Azure DevOps task for Infracost along with examples of how you can use it to to see cloud cost estimates for Terraform in pull requests 💰
+This project provides Azure Pipeline tasks for Infracost along with examples of how you can use it to to see cloud cost estimates for Terraform in pull requests 💰
 
 <img src="screenshot.png" width="700px" alt="Example screenshot" />
 
 ## Quick start
 
-The Azure DevOps Infracost tasks can be used with either Azure Repos (only git is supported) or GitHub repos. The following steps assume a simple Terraform directory is being used, we recommend you use a more relevant [example](#examples) if required.
+The Azure Pipelines Infracost tasks can be used with either Azure Repos (only git is supported) or GitHub repos. The following steps assume a simple Terraform directory is being used, we recommend you use a more relevant [example](#examples) if required.
 
 1. In the Azure DevOps Marketplace, Add the [Terraform installer task](https://marketplace.visualstudio.com/items?itemName=ms-devlabs.custom-terraform-tasks) to your organization by clicking 'Get it free', selecting your organization and clicking Install. If you do not have permission to install the task, you can submit a request to your organization's admin who will get emailed the details of the request.
 
@@ -20,7 +20,7 @@ The Azure DevOps Infracost tasks can be used with either Azure Repos (only git i
 
 ## Azure Repos Quick start
 
-1. Enable pull request build triggers. Without this, Azure DevOps Pipelines do not trigger builds with the pull request ID, thus comments cannot be posted by the integration.
+1. Enable pull request build triggers. Without this, Azure Pipelines do not trigger builds with the pull request ID, thus comments cannot be posted by the integration.
 
     a. From your Azure DevOps organization, click on your project > Project Settings > Repositories > your repository
 
@@ -30,7 +30,7 @@ The Azure DevOps Infracost tasks can be used with either Azure Repos (only git i
 
     d. Select your 'Build pipeline', leave 'Path filter' blank, set 'Trigger' to Automatic, and 'Policy requirement' to Optional (you can also use Required but we don't recommend it).
 
-2. Enable DevOps Pipelines to post pull request comments
+2. Enable Azure Pipelines to post pull request comments
 
     a. From your Azure DevOps organization, click on your project > Project Settings > Repositories > your repository
 
@@ -48,7 +48,7 @@ The Azure DevOps Infracost tasks can be used with either Azure Repos (only git i
 4.  Add the following to the `azure-pipelines.yml` file:
 
     ```yaml
-    # The Azure DevOps docs (https://docs.microsoft.com/en-us/azure/devops/pipelines/process/tasks) describe other options.
+    # The Azure Pipelines docs (https://docs.microsoft.com/en-us/azure/devops/pipelines/process/tasks) describe other options.
     # Running on pull requests to `master` (or your default branch) is a good default.
     pr:
       - master
@@ -118,7 +118,7 @@ The Azure DevOps Infracost tasks can be used with either Azure Repos (only git i
 
 ## GitHub Repos Quick Start
 
-1. Create a GitHub token (such as Personal Access Token) that can be used by the Azure DevOps Pipeline to post comments. The token needs to have `repo` scope so it can post comments.
+1. Create a GitHub token (such as Personal Access Token) that can be used by the pipeline to post comments. The token needs to have `repo` scope so it can post comments.
 
 2. Add secret variables: from your Azure DevOps organization, click on your project > Pipelines > your pipeline > Edit > Variables, and click the + sign to add variables for the following":
 
@@ -133,7 +133,7 @@ The Azure DevOps Infracost tasks can be used with either Azure Repos (only git i
 3.  Add the following to the `azure-pipelines.yml` file:
 
     ```yaml
-    # The Azure DevOps docs (https://docs.microsoft.com/en-us/azure/devops/pipelines/process/tasks) describe other options.
+    # The Azure Pipelines docs (https://docs.microsoft.com/en-us/azure/devops/pipelines/process/tasks) describe other options.
     # Running on pull requests to `master` (or your default branch) is a good default.
     pr:
       - master
@@ -210,7 +210,7 @@ The [examples](examples) directory demonstrates how these actions can be used in
   - [Terragrunt](examples/terragrunt): a Terragrunt project
   - [Terraform Cloud/Enterprise](examples/terraform-cloud-enterprise): a Terraform project using Terraform Cloud/Enterprise
   - [Multi-project using config file](examples/multi-project/README.md#using-an-infracost-config-file): multiple Terraform projects using the Infracost [config file](https://www.infracost.io/docs/multi_project/config_file)
-  - [Multi-project using build matrix](examples/multi-project/README.md#using-azure-devops-pipeline-matrix-strategy): multiple Terraform projects using Azure DevOps Pipeline matrix strategy
+  - [Multi-project using build matrix](examples/multi-project/README.md#using-azure-devops-pipeline-matrix-strategy): multiple Terraform projects using the Azure pipelines matrix strategy
   - [Multi-Terraform workspace](examples/multi-terraform-workspace): multiple Terraform workspaces using the Infracost [config file](https://www.infracost.io/docs/multi_project/config_file)
   - [Private Terraform module](examples/private-terraform-module/README.md): a Terraform project using a private Terraform module
   - [Slack](examples/slack): send cost estimates to Slack

--- a/README.md
+++ b/README.md
@@ -2,47 +2,75 @@
 
 This project provides an Azure DevOps task for Infracost along with examples of how you can use it to to see cloud cost estimates for Terraform in pull requests 💰
 
-<img src="screenshot.png" width="800px" alt="Example screenshot" />
+<img src="screenshot.png" width="700px" alt="Example screenshot" />
 
 ## Quick start
 
-The following steps assume a simple Terraform directory is being used, we recommend you use a more relevant [example](#examples) if required.
+The Azure DevOps Infracost tasks can be used with either Azure Repos (only git is supported) or GitHub repos. The following steps assume a simple Terraform directory is being used, we recommend you use a more relevant [example](#examples) if required.
 
-1. Retrieve your Infracost API key by running `infracost configure get api_key`. If you don't have one, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost register` to get a free API key.
+1. In the Azure DevOps Marketplace, Add the [Terraform installer task](https://marketplace.visualstudio.com/items?itemName=ms-devlabs.custom-terraform-tasks) to your organization by clicking 'Get it free', selecting your organization and clicking Install. If you do not have permission to install the task, you can submit a request to your organization's admin who will get emailed the details of the request.
 
-2. In your Azure DevOps project create a new pipeline by going to 'Pipelines' > 'New pipeline', connect to your code repo and select 'Starter pipeline'.
+2. Repeat step 1 for the [Infracost tasks](TODO: add link).
 
-3. Add the following pipeline variables:
+3. Retrieve your Infracost API key by running `infracost configure get api_key`. If you don't have one, [download Infracost](https://www.infracost.io/docs/#quick-start) and run `infracost register` to get a free API key.
 
-    - `infracostApiKey` with your Infracost API key as the value, and select 'Keep this value secret'.
-    - `githubToken` with your GitHub access token as the value if your repository provider is GitHub. Select 'Keep this value secret'.
-    - `azureReposToken` with your Azure Repos access token as the value if your repository provider is Azure Repos. Select 'Keep this value secret'.
+4. If you are using an Azure Repos repositories follow the [Azure Repos quick start](#azure-repos-quick-start). Currently this only supports Git repositories.
 
-4. Create required variables for any cloud credentials that are needed for Terraform to run.
+5. If you are using a GitHub repository follow the [GitHub Repos quick start](#github-repos-quick-start)
 
-    - **Terraform Cloud/Enterprise users**: the [Terraform docs](https://www.terraform.io/cli/config/config-file#credentials-1) explain how to configure credentials for this using a config file, or you can pass the credentials as environment variables directly to Infracost as in [this example](examples/terraform-cloud-enterprise).
-    - **AWS users**: the [Terraform docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#environment-variables) explain the environment variables to set for this.
-    - **Azure users**: the [Terraform docs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret) explain the options.
-    - **Google users**: the [Terraform docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#full-reference) explain the options, e.g. using `GOOGLE_CREDENTIALS`.
+## Azure Repos Quick start
 
-5.  Add the following to the `azure-pipelines.yml` file:
+1. Enable pull request build triggers. Without this, Azure DevOps Pipelines do not trigger builds with the pull request ID, thus comments cannot be posted by the integration.
+
+    a. From your Azure DevOps organization, click on your project > Project Settings > Repositories > your repository
+
+    b. Select the Policies tab and under the Branch Policies select on your default branch (master or main)
+
+    c. Scroll to Build Validation and click + sign to add one if you don't have one already
+
+    d. Select your 'Build pipeline', leave 'Path filter' blank, set 'Trigger' to Automatic, and 'Policy requirement' to Optional (you can also use Required but we don't recommend it).
+
+2. Enable DevOps Pipelines to post pull request comments
+
+    a. From your Azure DevOps organization, click on your project > Project Settings > Repositories > your repository
+
+    b. Click on the Securities tab, scroll down to Users and click on the '[project name] Build Service ([org name])' user, and set the 'Contribute to pull requests' to Allow.
+
+3. Add secret variables: from your Azure DevOps organization, click on your project > Pipelines > your pipeline > Edit > Variables, and click the + sign to add variables for the following. Also tick the 'Keep this value secret' option.
+
+    - `infracostApiKey`: with your Infracost API key as the value, and select 'Keep this value secret'.
+    - Any cloud provider credentials you need for running `terraform init` and `terraform plan`:
+      - **Terraform Cloud/Enterprise users**: the [Terraform docs](https://www.terraform.io/cli/config/config-file#credentials-1) explain how to configure credentials for this using a config file, or you can pass the credentials as environment variables directly to Infracost as in [this example](examples/terraform-cloud-enterprise).
+      - **AWS users**: the [Terraform docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#environment-variables) explain the environment variables to set for this.
+      - **Azure users**: the [Terraform docs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret) explain the options.
+      - **Google users**: the [Terraform docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#full-reference) explain the options, e.g. using `GOOGLE_CREDENTIALS`.
+
+4.  Add the following to the `azure-pipelines.yml` file:
 
     ```yaml
+    # The Azure DevOps docs (https://docs.microsoft.com/en-us/azure/devops/pipelines/process/tasks) describe other options.
+    # Running on pull requests to `master` (or your default branch) is a good default.
     pr:
       - master
 
     variables:
-      TF_ROOT: PATH/TO/TERRAFORM/CODE
+      TF_ROOT: PATH/TO/TERRAFORM/CODE # Update this!
 
     jobs:
-      - job: terraform_plan_json
-        displayName: Terraform plan JSON
+      - job: infracost
+        displayName: Run Infracost
         pool:
           vmImage: ubuntu-latest
 
         steps:
+            # Typically the Infracost actions will be used in conjunction with the Terraform tool installer task.
+            # If this task is not available you can add it to your org from https://marketplace.visualstudio.com/items?itemName=ms-devlabs.custom-terraform-tasks.
+            # Subsequent steps can run Terraform commands as bash tasks. Alternatively, the Terraform tasks
+            # can be used, but we recommend bash tasks since they are simpler.
           - task: TerraformInstaller@0
             displayName: Install Terraform
+
+          # IMPORTANT: add any required steps here to setup cloud credentials so Terraform can run
 
           - bash: terraform init
             displayName: Terraform init
@@ -56,25 +84,121 @@ The following steps assume a simple Terraform directory is being used, we recomm
             displayName: Terraform show
             workingDirectory: $(TF_ROOT)
 
+          # Install the Infracost CLI, see https://github.com/infracost/actions/tree/master/overview.md#infracostsetup-task
+          # for other inputs such as version, and pricingApiEndpoint (for self-hosted users).
           - task: InfracostSetup@0
             displayName: Setup Infracost
             inputs:
               apiKey: $(infracostApiKey)
 
+          # Run Infracost and generate the JSON output, the following docs might be useful:
+          # Multi-project/workspaces: https://www.infracost.io/docs/features/config_file
+          # Combine Infracost JSON files: https://www.infracost.io/docs/features/cli_commands/#combined-output-formats
           - bash: infracost breakdown --path=$(TF_ROOT)/plan.json --format=json --out-file=/tmp/infracost.json
             displayName: Run Infracost
 
+          # See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
           - task: InfracostComment@0
-            displayName: Post the comment
+            displayName: Post Infracost comment
             inputs:
-              githubToken: $(githubToken)
+              azureReposToken: $(System.AccessToken) # Do not change this, it's used to post comments
               path: /tmp/infracost.json
-              behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#comment-options for other options
+              # Choose the commenting behavior, 'update' is a good default:
+              behavior: update # Create a single comment and update it. The "quietest" option.
+              # behavior: delete-and-new # Delete previous comments and create a new one.
+              # behavior: hide-and-new # Minimize previous comments and create a new one.
+              # behavior: new # Create a new cost estimate comment on every push.
     ```
 
-6. Click 'Save and run'
+5. Click 'Save and run'
 
-7. 🎉 That's it! Send a new pull request to change something in Terraform that costs money. You should see a pull request comment that gets updated, e.g. the 📉 and 📈 emojis will update as changes are pushed!
+6. 🎉 That's it! Send a new pull request to change something in Terraform that costs money. You should see a pull request comment that gets updated, e.g. the 📉 and 📈 emojis will update as changes are pushed!
+
+    If there are issues, you can enable the 'Enable system diagnostics' check box when running the pipeline manually or for more options see [this page](https://docs.microsoft.com/en-us/azure/devops/pipelines/troubleshooting/review-logs).
+
+## GitHub Repos Quick Start
+
+1. Create a GitHub token (such as Personal Access Token) that can be used by the Azure DevOps Pipeline to post comments. The token needs to have `repo` scope so it can post comments.
+
+2. Add secret variables: from your Azure DevOps organization, click on your project > Pipelines > your pipeline > Edit > Variables, and click the + sign to add variables for the following":
+
+    - `infracostApiKey`: with your Infracost API key as the value, and select 'Keep this value secret'.
+    - `githubToken` with your GitHub access token as the value, and select 'Keep this value secret'.
+    - Any cloud provider credentials you need for running `terraform init` and `terraform plan`:
+      - **Terraform Cloud/Enterprise users**: the [Terraform docs](https://www.terraform.io/cli/config/config-file#credentials-1) explain how to configure credentials for this using a config file, or you can pass the credentials as environment variables directly to Infracost as in [this example](examples/terraform-cloud-enterprise).
+      - **AWS users**: the [Terraform docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#environment-variables) explain the environment variables to set for this.
+      - **Azure users**: the [Terraform docs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret) explain the options.
+      - **Google users**: the [Terraform docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#full-reference) explain the options, e.g. using `GOOGLE_CREDENTIALS`.
+
+3.  Add the following to the `azure-pipelines.yml` file:
+
+    ```yaml
+    # The Azure DevOps docs (https://docs.microsoft.com/en-us/azure/devops/pipelines/process/tasks) describe other options.
+    # Running on pull requests to `master` (or your default branch) is a good default.
+    pr:
+      - master
+
+    variables:
+      TF_ROOT: PATH/TO/TERRAFORM/CODE # Update this!
+
+    jobs:
+      - job: infracost
+        displayName: Run Infracost
+        pool:
+          vmImage: ubuntu-latest
+
+        steps:
+            # Typically the Infracost actions will be used in conjunction with the Terraform tool installer task
+            # If this task is not available you can add it to your org from https://marketplace.visualstudio.com/items?itemName=ms-devlabs.custom-terraform-tasks.
+            # Subsequent steps can run Terraform commands as they would in the shell.
+          - task: TerraformInstaller@0
+            displayName: Install Terraform
+
+          # IMPORTANT: add any required steps here to setup cloud credentials so Terraform can run
+
+          - bash: terraform init
+            displayName: Terraform init
+            workingDirectory: $(TF_ROOT)
+
+          - bash: terraform plan -out tfplan.binary
+            displayName: Terraform plan
+            workingDirectory: $(TF_ROOT)
+
+          - bash: terraform show -json tfplan.binary > plan.json
+            displayName: Terraform show
+            workingDirectory: $(TF_ROOT)
+
+          # Install the Infracost CLI, see https://github.com/infracost/actions/tree/master/tasks/setup/overview.md
+          # for other inputs such as version, and pricingApiEndpoint (for self-hosted users).
+          - task: InfracostSetup@0
+            displayName: Setup Infracost
+            inputs:
+              apiKey: $(infracostApiKey)
+
+          # Run Infracost and generate the JSON output, the following docs might be useful:
+          # Multi-project/workspaces: https://www.infracost.io/docs/features/config_file
+          # Combine Infracost JSON files: https://www.infracost.io/docs/features/cli_commands/#combined-output-formats
+          - bash: infracost breakdown --path=$(TF_ROOT)/plan.json --format=json --out-file=/tmp/infracost.json
+            displayName: Run Infracost
+
+          # See https://github.com/infracost/infracost-azure-devops/tree/master/tasks/comment/overview.md for other options
+          - task: InfracostComment@0
+            displayName: Post Infracost comment
+            inputs:
+              githubToken: $(githubToken) # Required to post comments
+              path: /tmp/infracost.json
+              # Choose the commenting behavior, 'update' is a good default:
+              behavior: update # Create a single comment and update it. The "quietest" option.
+              # behavior: delete-and-new # Delete previous comments and create a new one.
+              # behavior: hide-and-new # Minimize previous comments and create a new one.
+              # behavior: new # Create a new cost estimate comment on every push.
+              # Limit the object that should be commented on, either merge-request or commit
+              # targetType: pull-request
+    ```
+
+4. Click 'Save and run'
+
+5. 🎉 That's it! Send a new pull request to change something in Terraform that costs money. You should see a pull request comment that gets updated, e.g. the 📉 and 📈 emojis will update as changes are pushed!
 
     If there are issues, you can enable the 'Enable system diagnostics' check box when running the pipeline manually or for more options see [this page](https://docs.microsoft.com/en-us/azure/devops/pipelines/troubleshooting/review-logs).
 
@@ -95,20 +219,14 @@ Cost policy examples:
 - [Thresholds](examples/thresholds): only post a comment when cost thresholds are exceeded
 - [Conftest](examples/conftest): check Infracost cost estimates against policies using Conftest
 - [OPA](examples/opa): check Infracost cost estimates against policies using Open Policy Agent
-- [Sentinel](examples/sentinel): check Infracost cost estimates against policies using Hashicorp's Sentinel
+- [Sentinel](examples/sentinel): check Infracost cost estimates against policies using HashiCorp's Sentinel
 
-## Comment options
+## Tasks
 
-For different commenting options specify the following inputs to the `InfracostComment` task:
+* We recommend you use the above quick start guide and examples, which combine the following individual actions:
 
-- `behavior`: Optional, defaults to `update`. The behavior to use when posting cost estimate comments. Must be one of the following:
-  - `update`: Create a single comment and update it on changes. This is the "quietest" option. pull request followers will only be notified on the comment create (not updates), and the comment will stay at the same location in the comment history.
-  - `delete-and-new`: Delete previous cost estimate comments and create a new one. pull request followers will be notified on each comment.
-  - `new`: Create a new cost estimate comment. pull request followers will be notified on each comment.
-
-- `targetType`: Optional. Which objects should be commented on, either `pull-request` or `commit`.
-
-- `tag`:  Optional. Customize the comment tag. This is added to the comment as a markdown comment (hidden) to detect the previously posted comments. This is useful if you have multiple workflows that post comments to the same pull request or commit.
+- [InfracostSetup](overview.md#infracostsetup-task): installs and configures Infracost CLI.
+- [InfracostComment](overview.md#infracostcomment-task): adds comments to GitHub pull requests and commits, or Azure Repos pull requests.
 
 ## Contributing
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ All examples post a single comment on merge requests, which gets updated as more
 - [Terragrunt](terragrunt): a Terragrunt project
 - [Terraform Cloud/Enterprise](terraform-cloud-enterprise): a Terraform project using Terraform Cloud/Enterprise
 - [Multi-project using config file](multi-project/README.md#using-an-infracost-config-file): multiple Terraform projects using the Infracost [config file](https://www.infracost.io/docs/multi_project/config_file)
-- [Multi-project using build matrix](multi-project/README.md#using-azure-devops-pipeline-matrix-strategy): multiple Terraform projects using Azure DevOps Pipeline matrix strategy
+- [Multi-project using build matrix](multi-project/README.md#using-azure-devops-pipeline-matrix-strategy): multiple Terraform projects using the Azure Pipelines matrix strategy
 - [Multi-Terraform workspace](multi-terraform-workspace): multiple Terraform workspaces using the Infracost [config file](https://www.infracost.io/docs/multi_project/config_file)
 - [Slack](slack): send cost estimates to Slack
 
@@ -15,6 +15,6 @@ Cost policy examples:
 - [Thresholds](thresholds): only post a comment when cost thresholds are exceeded
 - [Conftest](conftest): check Infracost cost estimates against policies using Conftest
 - [OPA](opa): check Infracost cost estimates against policies using Open Policy Agent
-- [Sentinel](sentinel): check Infracost cost estimates against policies using Hashicorp's Sentinel 
+- [Sentinel](sentinel): check Infracost cost estimates against policies using Hashicorp's Sentinel
 
 See the [contributing](../CONTRIBUTING.md) guide if you'd like to add an example.

--- a/examples/multi-project/README.md
+++ b/examples/multi-project/README.md
@@ -1,10 +1,10 @@
 # Multi-project
 
-These examples show how to run Infracost Azure DevOps tasks against a multi-project setup using either an [Infracost config file](https://www.infracost.io/docs/multi_project/config_file) or These examples show how to run Infracost Azure DevOps tasks against a multi-project setup using either an [Infracost config file](https://www.infracost.io/docs/multi_project/config_file) or the Azure DevOps pipeline matrix strategy.
+These examples show how to run Infracost Azure Pipelines tasks against a multi-project setup using either an [Infracost config file](https://www.infracost.io/docs/multi_project/config_file) or These examples show how to run Infracost Azure Pipelines tasks against a multi-project setup using either an [Infracost config file](https://www.infracost.io/docs/multi_project/config_file) or the Azure Pipelines matrix strategy.
 
 ## Using an Infracost config file
 
-This example shows how to run Infracost Azure DevOps tasks with multiple Terraform projects using an [Infracost config file](https://www.infracost.io/docs/multi_project/config_file).
+This example shows how to run Infracost Azure Pipelines tasks with multiple Terraform projects using an [Infracost config file](https://www.infracost.io/docs/multi_project/config_file).
 
 [//]: <> (BEGIN EXAMPLE)
 ```yml
@@ -44,9 +44,9 @@ jobs:
 ```
 [//]: <> (END EXAMPLE)
 
-## Using Azure DevOps Pipeline matrix strategy
+## Using Azure Pipelines matrix strategy
 
-This example shows how to run Infracost Azure DevOps tasks with multiple Terraform projects using the Azure DevOps Pipeline matrix strategy. The first job uses a matrix strategy to generate multiple Infracost output JSON files and upload them as artifacts. The second job downloads these JSON files, combines them using `infracost output`, and posts a comment.
+This example shows how to run Infracost Azure Pipelines tasks with multiple Terraform projects using the Azure Pipelines matrix strategy. The first job uses a matrix strategy to generate multiple Infracost output JSON files and upload them as artifacts. The second job downloads these JSON files, combines them using `infracost output`, and posts a comment.
 
 [//]: <> (BEGIN EXAMPLE)
 ```yml

--- a/examples/multi-project/README.md
+++ b/examples/multi-project/README.md
@@ -40,7 +40,7 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#infracostcomment for other options
 ```
 [//]: <> (END EXAMPLE)
 
@@ -120,6 +120,6 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost_combined.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#infracostcomment for other options
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/multi-project/README.md
+++ b/examples/multi-project/README.md
@@ -40,7 +40,7 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#comment-options for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
 ```
 [//]: <> (END EXAMPLE)
 
@@ -120,6 +120,6 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost_combined.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#comment-options for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/multi-terraform-workspace/README.md
+++ b/examples/multi-terraform-workspace/README.md
@@ -37,6 +37,6 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#comment-options for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/multi-terraform-workspace/README.md
+++ b/examples/multi-terraform-workspace/README.md
@@ -37,6 +37,6 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#infracostcomment for other options
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/multi-terraform-workspace/README.md
+++ b/examples/multi-terraform-workspace/README.md
@@ -1,6 +1,6 @@
 # Multi-Terraform workspace
 
-This example shows how to run Infracost in an Azure DevOps pipeline against a Terraform project that uses multiple workspaces using an [Infracost config file](https://www.infracost.io/docs/multi_project/config_file).
+This example shows how to run Infracost in Azure Pipelines against a Terraform project that uses multiple workspaces using an [Infracost config file](https://www.infracost.io/docs/multi_project/config_file).
 
 [//]: <> (BEGIN EXAMPLE)
 ```yml

--- a/examples/opa/README.md
+++ b/examples/opa/README.md
@@ -2,7 +2,7 @@
 
 This example shows how to set cost policies using [Open Policy Agent](https://www.openpolicyagent.org/).  For simplicity, this is based off the terraform-plan-json example, which does not require Terraform to be installed.
 
-When the policy checks pass, the Azure DevOps pipeline step called "Check Policies" passes and outputs `Policy check passed.` in the task logs. When the policy checks fail, that step fails and the task logs show the details of the failing policies.
+When the policy checks pass, the pipeline step called "Check Policies" passes and outputs `Policy check passed.` in the task logs. When the policy checks fail, that step fails and the task logs show the details of the failing policies.
 
 Create a policy file (e.g. `policy.rego`) that checks the Infracost JSON:
 ```rego

--- a/examples/private-terraform-module/README.md
+++ b/examples/private-terraform-module/README.md
@@ -43,6 +43,6 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#infracostcomment for other options
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/private-terraform-module/README.md
+++ b/examples/private-terraform-module/README.md
@@ -43,6 +43,6 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#comment-options for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/private-terraform-module/README.md
+++ b/examples/private-terraform-module/README.md
@@ -1,6 +1,6 @@
 # Private Terraform module
 
-This example shows how to run Infracost in an Azure DevOps pipeline with a Terraform project that uses a private Terraform module. This requires a secret to be added to your GitHub repository called `gitSshKeyBase464` containing a base 64 encoded private key so that Terraform can access the private repository.
+This example shows how to run Infracost in Azure Pipelines with a Terraform project that uses a private Terraform module. This requires a secret to be added to your GitHub repository called `gitSshKeyBase464` containing a base 64 encoded private key so that Terraform can access the private repository.
 
 [//]: <> (BEGIN EXAMPLE)
 ```yml

--- a/examples/sentinel/README.md
+++ b/examples/sentinel/README.md
@@ -2,7 +2,7 @@
 
 This example shows how to write cost policies with HashiCorp's [Sentinel](https://www.hashicorp.com/sentinel). For simplicity, this example evaluates policies with the Sentinel CLI (a.k.a. Sentinel Simulator). The point of this example is to show how a policy could be written against the Infracost JSON format, not how to run Sentinel, since that's tied to HashiCorp's cloud platform.
 
-When the policy checks pass, the Azure Devops pipeline step called "Check Policies" passes and outputs `Policy check passed.` in the task logs. When the policy checks fail, that step fails and the task logs show the Sentinel output indicating failing policies.
+When the policy checks pass, the pipeline step called "Check Policies" passes and outputs `Policy check passed.` in the task logs. When the policy checks fail, that step fails and the task logs show the Sentinel output indicating failing policies.
 
 Create a policy file (e.g. `policy.policy) that checks a global parameter 'breakdown' containing the Infracost JSON:
 ```policy

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -33,7 +33,7 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#infracostcomment for other options
 
       - bash: infracost output --path /tmp/infracost.json --format slack-message --show-skipped --out-file /tmp/slack-message.json
         displayName: Generate Slack message

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -1,6 +1,6 @@
 # Slack Example
 
-This example shows how to send cost estimates to Slack using Azure DevOps pipeline tasks.
+This example shows how to send cost estimates to Slack using Infracost Azure Pipelines tasks.
 
 Slack message blocks have a 3000 char limit so the Infracost CLI automatically truncates the middle of slack-message output formats.
 

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -33,7 +33,7 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#comment-options for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
 
       - bash: infracost output --path /tmp/infracost.json --format slack-message --show-skipped --out-file /tmp/slack-message.json
         displayName: Generate Slack message

--- a/examples/terraform-cloud-enterprise/README.md
+++ b/examples/terraform-cloud-enterprise/README.md
@@ -36,6 +36,6 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#infracostcomment for other options
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/terraform-cloud-enterprise/README.md
+++ b/examples/terraform-cloud-enterprise/README.md
@@ -36,6 +36,6 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#comment-options for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/terraform-cloud-enterprise/README.md
+++ b/examples/terraform-cloud-enterprise/README.md
@@ -1,6 +1,6 @@
 # Terraform Cloud/Enterprise
 
-This example shows how to run Infracost in an Azure DevOps pipeline with Terraform Cloud and Terraform Enterprise. It assumes you have set a pipeline secret variable for the Terraform Cloud token (`tfcToken`). This token is used by the Infracost CLI run a speculative plan and fetch the plan JSON from Terraform Cloud to generate the cost estimate comment.
+This example shows how to run Infracost in Azure Pipelines with Terraform Cloud and Terraform Enterprise. It assumes you have set a pipeline secret variable for the Terraform Cloud token (`tfcToken`). This token is used by the Infracost CLI run a speculative plan and fetch the plan JSON from Terraform Cloud to generate the cost estimate comment.
 
 
 [//]: <> (BEGIN EXAMPLE)

--- a/examples/terraform-directory/README.md
+++ b/examples/terraform-directory/README.md
@@ -30,7 +30,7 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#infracostcomment for other options
 
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/terraform-directory/README.md
+++ b/examples/terraform-directory/README.md
@@ -30,7 +30,7 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#comment-options for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
 
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/terraform-directory/README.md
+++ b/examples/terraform-directory/README.md
@@ -1,6 +1,6 @@
 # Terraform directory
 
-This example shows how to run Infracost Azure DevOps tasks with a Terraform project containing HCL code.
+This example shows how to run Infracost Azure Pipelines tasks with a Terraform project containing HCL code.
 
 [//]: <> (BEGIN EXAMPLE)
 ```yml

--- a/examples/terraform-plan-json/README.md
+++ b/examples/terraform-plan-json/README.md
@@ -27,6 +27,6 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#infracostcomment for other options
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/terraform-plan-json/README.md
+++ b/examples/terraform-plan-json/README.md
@@ -27,6 +27,6 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#comment-options for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/terragrunt/README.md
+++ b/examples/terragrunt/README.md
@@ -1,6 +1,6 @@
 # Terragrunt
 
-This example shows how to run Infracost Azure DevOps tasks with Terragrunt.
+This example shows how to run Infracost Azure Pipeline tasks with Terragrunt.
 
 [//]: <> (BEGIN EXAMPLE)
 ```yml

--- a/examples/terragrunt/README.md
+++ b/examples/terragrunt/README.md
@@ -41,6 +41,6 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#comment-options for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/terragrunt/README.md
+++ b/examples/terragrunt/README.md
@@ -41,6 +41,6 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#infracostcomment for other options
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/thresholds/README.md
+++ b/examples/thresholds/README.md
@@ -66,6 +66,6 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#infracostcomment for other options
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/thresholds/README.md
+++ b/examples/thresholds/README.md
@@ -53,12 +53,12 @@ jobs:
 
       - task: InfracostComment@0
         displayName: Post the comment
-        # Setup the conditions for the task to comment on the pipeline. We use the lt expression (less than): 
+        # Setup the conditions for the task to comment on the pipeline. We use the lt expression (less than):
         # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#lt
         # as azure automatically casts the RIGHT parameter to the type of the LEFT. Variables set in
-        # task always evaluate to strings, which means using numerical expressions like lt & gt with variables as the 
+        # task always evaluate to strings, which means using numerical expressions like lt & gt with variables as the
         # first parameter are likely to perform incorrectly. e.g:
-        #   if a absolutePercentChange is set to '999' then gt(variables.absolutePercentChange, 1000) will evaluate to true.  
+        #   if a absolutePercentChange is set to '999' then gt(variables.absolutePercentChange, 1000) will evaluate to true.
         condition: lt(1, variables.absolutePercentChange) # Only comment if cost changed by more than plus or minus 1%
         # condition: lt(1, variables.percentChange) # Only comment if cost increased by more than 1%
         # condition: lt(100, variables.absoluteCostChange) # Only comment if cost changed by more than plus or minus $100
@@ -66,6 +66,6 @@ jobs:
         inputs:
           githubToken: $(githubToken)
           path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#comment-options for other options
+          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/overview.md#infracostcomment-task for other options
 ```
 [//]: <> (END EXAMPLE)

--- a/overview.md
+++ b/overview.md
@@ -4,7 +4,7 @@ This extension provides tasks to setup and use [Infracost](https://www.infracost
 
 # How to use
 
-After installing this extension you can use it in tasks in [your pipeline](https://docs.microsoft.com/en-us/azure/devops/pipelines/).
+After installing this extension you can use it in tasks in your Azure pipeline. See [the quick start on GitHub](https://github.com/infracost/infracost-azure-devops) to get started.
 
 # Available tasks
 
@@ -71,9 +71,9 @@ The action supports the following inputs:
 - `behavior`: Optional, defaults to `update`. The behavior to use when posting cost estimate comments. Must be one of the following:
   - `update`: Create a single comment and update it on changes. This is the "quietest" option. The Azure DevOps Repos/GitHub comments UI shows what/when changed when the comment is updated. Pull request followers will only be notified on the comment create (not updates), and the comment will stay at the same location in the comment history.
   - `delete-and-new`: Delete previous cost estimate comments and create a new one. Pull request followers will be notified on each comment.
-  - `hide-and-new`: Minimize previous cost estimate comments and create a new one. Pull request followers will be notified on each comment.
+  - `hide-and-new` (only available for GitHub repos): Minimize previous cost estimate comments and create a new one. Pull request followers will be notified on each comment.
   - `new`: Create a new cost estimate comment. Pull request followers will be notified on each comment.
-- `targetType`: Optional. Which objects should be commented on, either `pull-request` or `commit`. The `commit` option is available only for GitHub repositories.
+- `targetType`: Optional. Which objects should be commented on, either `pull-request` or `commit`. The `commit` option is available only for GitHub repos.
 - `tag`: Optional. Customize the comment tag. This is added to the comment as a markdown comment (hidden) to detect the previously posted comments. This is useful if you have multiple pipelines that post comments to the same pull request or commit.
 
 ### Outputs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infracost-azure-devops",
-  "description": "Infracost Azure DevOps Pipeline Tasks",
+  "description": "Infracost Azure Pipeline Tasks",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/infracost/infracost-azure-devops.git"

--- a/scripts/generateExamplesTests.js
+++ b/scripts/generateExamplesTests.js
@@ -23,7 +23,7 @@ function extractAllExamples(examplesDir) {
     }
 
     console.log(
-      `Generating Azure DevOps Pipeline job for ${examplesDir}/${dir}`
+      `Generating Azure Pipelines job for ${examplesDir}/${dir}`
     );
 
     const filename = `${examplesDir}/${dir}/README.md`;

--- a/tasks/InfracostSetup/task.json
+++ b/tasks/InfracostSetup/task.json
@@ -3,7 +3,7 @@
   "id": "b7cd5a2e-1c4c-4f61-8b25-ba72cf4fc8ce",
   "name": "InfracostSetup",
   "friendlyName": "Infracost Setup Task",
-  "description": "Sets up Infracost CLI in your Azure DevOps pipeline. Show cloud cost estimates for Terraform in pull requests.",
+  "description": "Sets up Infracost CLI in Azure Pipelines. Show cloud cost estimates for Terraform in pull requests.",
   "helpMarkDown": "",
   "category": "Utility",
   "author": "Infracost",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -47,7 +47,7 @@
   ],
   "content": {
     "details": {
-      "path": "overview.md"
+      "path": "README.md"
     },
     "license": {
       "path": "LICENSE"

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -9,7 +9,7 @@
       "id": "Microsoft.VisualStudio.Services"
     }
   ],
-  "description": "Tasks for setting up Infracost in your Azure DevOps Pipelines and showing cloud cost estimates for Terraform in pull requests.",
+  "description": "Tasks for setting up Infracost in your Azure Pipelines and showing cloud cost estimates for Terraform in pull requests.",
   "tags": [
     "AWS",
     "Azure DevOps Extensions",


### PR DESCRIPTION
* Add instructions for adding the Terraform and Infracost tasks to the organization
* Add separate quick starts for Azure Repos and GitHub Repos
* Add inline comments to examples
* Add section linking to the different task docs
* Merge the README and overview so we have the same docs for GitHub and the Azure DevOps marketplace