### PR TITLE
chore: add dry run InfracostComment in example tests

### DIFF
--- a/.azure/pipelines/examples-test.yml
+++ b/.azure/pipelines/examples-test.yml
@@ -1,5 +1,6 @@
 pr:
   - master
+  - azure-devops-tasks
 name: Infracost.InfracostAzureDevops.Examples.Test
 jobs:
   - job: conftest
@@ -63,14 +64,16 @@ jobs:
           DEV_AWS_SECRET_ACCESS_KEY: $(exampleDevAwsSecretAccessKey)
           PROD_AWS_ACCESS_KEY_ID: $(exampleProdAwsAccessKeyId)
           PROD_AWS_SECRET_ACCESS_KEY: $(exampleProdAwsSecretAccessKey)
-      - bash: >-
-          infracost output --path=/tmp/infracost.json
-          --format=azure-repos-comment --show-skipped
-          --out-file=/tmp/infracost_comment.md
-        displayName: Generate Infracost comment
+      - task: InfracostComment@0
+        displayName: Post the comment
+        inputs:
+          githubToken: $(githubToken)
+          path: /tmp/infracost.json
+          behavior: update
+          dryRun: true
       - bash: >-
           diff ./testdata/multi_project_config_file_comment_golden.md
-          /tmp/infracost_comment.md
+          infracost-comment.md
         displayName: Check the comment
   - job: multi_project_matrix
     displayName: Multi-project matrix
@@ -128,14 +131,16 @@ jobs:
           infracost output --path="infracost_jsons/*.json" --format=json
           --out-file=/tmp/infracost_combined.json
         displayName: Combine the results
-      - bash: >-
-          infracost output --path=/tmp/infracost_combined.json
-          --format=azure-repos-comment --show-skipped
-          --out-file=/tmp/infracost_comment.md
-        displayName: Generate Infracost comment
+      - task: InfracostComment@0
+        displayName: Post the comment
+        inputs:
+          githubToken: $(githubToken)
+          path: /tmp/infracost_combined.json
+          behavior: update
+          dryRun: true
       - bash: >-
           diff ./testdata/multi_project_matrix_merge_comment_golden.md
-          /tmp/infracost_comment.md
+          infracost-comment.md
         displayName: Check the comment
   - job: multi_terraform_workspace_config_file
     displayName: Multi-Terraform workspace config file
@@ -158,15 +163,17 @@ jobs:
           DEV_AWS_SECRET_ACCESS_KEY: $(exampleDevAwsSecretAccessKey)
           PROD_AWS_ACCESS_KEY_ID: $(exampleProdAwsAccessKeyId)
           PROD_AWS_SECRET_ACCESS_KEY: $(exampleProdAwsSecretAccessKey)
-      - bash: >-
-          infracost output --path=/tmp/infracost.json
-          --format=azure-repos-comment --show-skipped
-          --out-file=/tmp/infracost_comment.md
-        displayName: Generate Infracost comment
+      - task: InfracostComment@0
+        displayName: Post the comment
+        inputs:
+          githubToken: $(githubToken)
+          path: /tmp/infracost.json
+          behavior: update
+          dryRun: true
       - bash: >-
           diff
           ./testdata/multi_terraform_workspace_config_file_comment_golden.md
-          /tmp/infracost_comment.md
+          infracost-comment.md
         displayName: Check the comment
   - job: open_policy_agent
     displayName: Open Policy Agent
@@ -240,14 +247,16 @@ jobs:
           infracost breakdown --path=examples/private-terraform-module/code
           --format=json --out-file=/tmp/infracost.json
         displayName: Run Infracost
-      - bash: >-
-          infracost output --path=/tmp/infracost.json
-          --format=azure-repos-comment --show-skipped
-          --out-file=/tmp/infracost_comment.md
-        displayName: Generate Infracost comment
+      - task: InfracostComment@0
+        displayName: Post the comment
+        inputs:
+          githubToken: $(githubToken)
+          path: /tmp/infracost.json
+          behavior: update
+          dryRun: true
       - bash: >-
           diff ./testdata/private_terraform_module_comment_golden.md
-          /tmp/infracost_comment.md
+          infracost-comment.md
         displayName: Check the comment
   - job: sentinel
     displayName: Sentinel
@@ -305,12 +314,14 @@ jobs:
           infracost breakdown --path examples/slack/code/plan.json --format json
           --out-file /tmp/infracost.json
         displayName: Run Infracost
-      - bash: >-
-          infracost output --path=/tmp/infracost.json
-          --format=azure-repos-comment --show-skipped
-          --out-file=/tmp/infracost_comment.md
-        displayName: Generate Infracost comment
-      - bash: diff ./testdata/slack_comment_golden.md /tmp/infracost_comment.md
+      - task: InfracostComment@0
+        displayName: Post the comment
+        inputs:
+          githubToken: $(githubToken)
+          path: /tmp/infracost.json
+          behavior: update
+          dryRun: true
+      - bash: diff ./testdata/slack_comment_golden.md infracost-comment.md
         displayName: Check the comment
       - bash: >-
           infracost output --path /tmp/infracost.json --format slack-message
@@ -338,14 +349,16 @@ jobs:
         env:
           INFRACOST_TERRAFORM_CLOUD_TOKEN: $(tfcToken)
           INFRACOST_TERRAFORM_CLOUD_HOST: app.terraform.io
-      - bash: >-
-          infracost output --path=/tmp/infracost.json
-          --format=azure-repos-comment --show-skipped
-          --out-file=/tmp/infracost_comment.md
-        displayName: Generate Infracost comment
+      - task: InfracostComment@0
+        displayName: Post the comment
+        inputs:
+          githubToken: $(githubToken)
+          path: /tmp/infracost.json
+          behavior: update
+          dryRun: true
       - bash: >-
           diff ./testdata/terraform_cloud_enterprise_comment_golden.md
-          /tmp/infracost_comment.md
+          infracost-comment.md
         displayName: Check the comment
   - job: terraform_directory
     displayName: Terraform Directory
@@ -362,14 +375,16 @@ jobs:
           infracost breakdown --path=examples/terraform-directory/code
           --format=json --out-file=/tmp/infracost.json
         displayName: Run Infracost
-      - bash: >-
-          infracost output --path=/tmp/infracost.json
-          --format=azure-repos-comment --show-skipped
-          --out-file=/tmp/infracost_comment.md
-        displayName: Generate Infracost comment
+      - task: InfracostComment@0
+        displayName: Post the comment
+        inputs:
+          githubToken: $(githubToken)
+          path: /tmp/infracost.json
+          behavior: update
+          dryRun: true
       - bash: >-
           diff ./testdata/terraform_directory_comment_golden.md
-          /tmp/infracost_comment.md
+          infracost-comment.md
         displayName: Check the comment
   - job: terraform_plan_json
     displayName: Terraform plan JSON
@@ -384,14 +399,16 @@ jobs:
           infracost breakdown --path=examples/terraform-plan-json/code/plan.json
           --format=json --out-file=/tmp/infracost.json
         displayName: Run Infracost
-      - bash: >-
-          infracost output --path=/tmp/infracost.json
-          --format=azure-repos-comment --show-skipped
-          --out-file=/tmp/infracost_comment.md
-        displayName: Generate Infracost comment
+      - task: InfracostComment@0
+        displayName: Post the comment
+        inputs:
+          githubToken: $(githubToken)
+          path: /tmp/infracost.json
+          behavior: update
+          dryRun: true
       - bash: >-
           diff ./testdata/terraform_plan_json_comment_golden.md
-          /tmp/infracost_comment.md
+          infracost-comment.md
         displayName: Check the comment
   - job: terragrunt
     displayName: Terragrunt
@@ -424,12 +441,14 @@ jobs:
           infracost breakdown --path=examples/terragrunt/code --format=json
           --out-file=/tmp/infracost.json
         displayName: Run Infracost
-      - bash: >-
-          infracost output --path=/tmp/infracost.json
-          --format=azure-repos-comment --show-skipped
-          --out-file=/tmp/infracost_comment.md
-        displayName: Generate Infracost comment
-      - bash: diff ./testdata/terragrunt_comment_golden.md /tmp/infracost_comment.md
+      - task: InfracostComment@0
+        displayName: Post the comment
+        inputs:
+          githubToken: $(githubToken)
+          path: /tmp/infracost.json
+          behavior: update
+          dryRun: true
+      - bash: diff ./testdata/terragrunt_comment_golden.md infracost-comment.md
         displayName: Check the comment
   - job: thresholds
     displayName: Thresholds
@@ -495,10 +514,13 @@ jobs:
 
           echo "##vso[task.setvariable variable=costChange;]${cost_change}"
         displayName: Calculate Cost Change
-      - bash: >-
-          infracost output --path=/tmp/infracost.json
-          --format=azure-repos-comment --show-skipped
-          --out-file=/tmp/infracost_comment.md
-        displayName: Generate Infracost comment
-      - bash: diff ./testdata/thresholds_comment_golden.md /tmp/infracost_comment.md
+      - task: InfracostComment@0
+        displayName: Post the comment
+        condition: lt(1, variables.absolutePercentChange)
+        inputs:
+          githubToken: $(githubToken)
+          path: /tmp/infracost.json
+          behavior: update
+          dryRun: true
+      - bash: diff ./testdata/thresholds_comment_golden.md infracost-comment.md
         displayName: Check the comment

--- a/examples/multi-project/README.md
+++ b/examples/multi-project/README.md
@@ -38,6 +38,7 @@ jobs:
       - task: InfracostComment@0
         displayName: Post the comment
         inputs:
+          githubToken: $(githubToken)
           path: /tmp/infracost.json
           behavior: update # Create a single comment and update it. See https://github.com/infracost/infracost-azure-devops#comment-options for other options
 ```

--- a/scripts/generateExamplesTests.js
+++ b/scripts/generateExamplesTests.js
@@ -72,16 +72,13 @@ function fixupExamples(examples) {
 
       for (const step of job.steps) {
         if (step.task && step.task.startsWith('InfracostComment')) {
-          const path = step.inputs.path;
           const goldenFilePath = `./testdata/${job.job}_comment_golden.md`;
+          step.inputs['dryRun'] = true
 
           steps.push(
+            step,
             {
-              bash: `infracost output --path=${path} --format=azure-repos-comment --show-skipped --out-file=/tmp/infracost_comment.md`,
-              displayName: 'Generate Infracost comment',
-            },
-            {
-              bash: `diff ${goldenFilePath} /tmp/infracost_comment.md`,
+              bash: `diff ${goldenFilePath} infracost-comment.md`,
               displayName: 'Check the comment',
             },
           );
@@ -116,7 +113,7 @@ function fixupExamples(examples) {
 }
 
 const pipelineSyntax = {
-  pr: ['master'],
+  pr: ['master', 'azure-devops-tasks'],
   name: 'Infracost.InfracostAzureDevops.Examples.Test',
   jobs: [],
 };

--- a/tasks/InfracostComment/index.ts
+++ b/tasks/InfracostComment/index.ts
@@ -27,7 +27,7 @@ function setEnvVariable(name: string, value: string, isSecret: boolean = false) 
 async function generateOutput(path: string, format: string, behavior: string): Promise<string> {
   const outputFile = 'infracost-comment.md';
 
-  let pathList: string[];
+  let pathList: string[] | string;
   try {
     pathList = JSON.parse(path);
 
@@ -150,6 +150,10 @@ function setupRepoProvider(): RepoProvider {
 
   setEnvVariable(provider.envVariable, token, true);
 
+  if (taskLib.getVariable('System.Debug') === 'true') {
+    setEnvVariable("DEBUG", "*")
+  }
+
   return provider;
 }
 
@@ -179,14 +183,14 @@ async function run() {
     // Send the comment
     const platform = compost.autodetect({
       logger: console,
-      tag: tag,
-      dryRun: dryRun,
+      tag,
+      dryRun,
       targetType: targetType as TargetType,
     });
     const postBehavior = behavior as PostBehavior;
 
     if (platform) {
-      platform.postComment(postBehavior, comment);
+      await platform.postComment(postBehavior, comment);
     }
   } catch (e: any) {
     let message = 'Failed to post a comment';

--- a/tasks/InfracostComment/task.json
+++ b/tasks/InfracostComment/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 6
+    "Patch": 10
   },
   "instanceNameFormat": "InfracostComment $(version)",
   "inputs": [
@@ -61,6 +61,14 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "Customize the comment tag. This is added to the comment as a markdown comment (hidden) to detect the previously posted comments. This is useful if you have multiple workflows that post comments to the same pull request or commit."
+    },
+    {
+      "name": "dryRun",
+      "type": "string",
+      "label": "Dry Run",
+      "defaultValue": false,
+      "required": false,
+      "helpMarkDown": "Skips any comment posting, deleting or hiding. The comment output is still saved to the $(Build.SourcesDirectory)/infracost-comment.md."
     }
   ],
   "execution": {

--- a/tasks/InfracostSetup/task.json
+++ b/tasks/InfracostSetup/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 6
+    "Patch": 10
   },
   "instanceNameFormat": "InfracostSetup $(version)",
   "inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "infracost-tasks",
   "name": "Infracost Tasks",
-  "version": "0.1.6",
+  "version": "0.1.10",
   "publisher": "Infracost",
   "targets": [
     {


### PR DESCRIPTION
* calls InfracostComment with dryRun flag to test `infracost output` and api interactions are sound