### PR TITLE
Fixing difference in cost always returned as 0

### DIFF
--- a/.azure/pipelines/examples-test.yml
+++ b/.azure/pipelines/examples-test.yml
@@ -32,6 +32,7 @@ jobs:
           '*.tfvars'  | xargs sed -i 's/t2.micro/t2.medium/g'
         displayName: Replace t2 instance
       - bash: |
+          cd -
           infracost diff --config-file=$(TF_ROOT)/infracost.yml \
                          --format=json \
                          --compare-to=/tmp/infracost-base.json \

--- a/examples/multi-project-config-file/README.md
+++ b/examples/multi-project-config-file/README.md
@@ -39,6 +39,7 @@ jobs:
         displayName: Generate Infracost cost estimate baseline
 
       - bash: |
+          cd -
           infracost diff --config-file=$(TF_ROOT)/infracost.yml \
                          --format=json \
                          --compare-to=/tmp/infracost-base.json \


### PR DESCRIPTION
In the example config, the latest change missed the correct location of comparison file. This PR fixes the same.