### PR TITLE
add example comments outlining a way to authenticate private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ The Azure Pipelines Infracost tasks can be used with either Azure Repos (only gi
           - bash: |
               branch=$(System.PullRequest.TargetBranch)
               branch=${branch#refs/heads/}
-              git clone $(Build.Repository.Uri) --branch=${branch} --single-branch /tmp/base
+              # uncomment the --config section if using a private git repository
+              git clone $(Build.Repository.Uri) --branch=${branch} --single-branch /tmp/base  # --config http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)"
             displayName: Checkout base branch
 
           # Generate an Infracost cost estimate baseline from the comparison branch, so that Infracost can compare the cost difference.

--- a/examples/sentinel/README.md
+++ b/examples/sentinel/README.md
@@ -93,7 +93,8 @@ jobs:
       - bash: |
           branch=$(System.PullRequest.TargetBranch)
           branch=${branch#refs/heads/}
-          git clone $(Build.Repository.Uri) --branch=${branch} --single-branch /tmp/base
+          # uncomment the --config section if using a private git repository
+          git clone ${repouri} --branch=${branch} --single-branch /tmp/base # --config http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)"
         displayName: Checkout base branch
 
       # Generate an Infracost cost estimate baseline from the comparison branch, so that Infracost can compare the cost difference.


### PR DESCRIPTION
I had a little fiddling to do in order to get the Azure Pipelines examples to authenticate to my private repos.

SSH keys worked, but I wasn't comfortable having a private key kept in variabless, so I added an example of using System.AccessToken instead.