### PR TITLE
fix: Bump extension version

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "infracost-tasks",
   "name": "Infracost Tasks",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "publisher": "Infracost",
   "targets": [
     {


### PR DESCRIPTION
It should go together with tasks/InfracostSetup/task.json.