### PR TITLE
Fix/use cached GitHub releases

### DIFF
--- a/tasks/InfracostSetup/index.ts
+++ b/tasks/InfracostSetup/index.ts
@@ -260,7 +260,7 @@ function exportEnvVars() {
   if (repoUrl) {
     taskLib.setVariable('INFRACOST_VCS_REPOSITORY_URL', repoUrl);
   }
-
+  
   const logLevel = taskLib.getVariable('System.Debug') === 'true' ? 'debug' : 'info';
   taskLib.setVariable('INFRACOST_LOG_LEVEL', logLevel)
 }

--- a/tasks/InfracostSetup/index.ts
+++ b/tasks/InfracostSetup/index.ts
@@ -225,7 +225,7 @@ interface Release {
  * @param name - the name of the repo
  */
 async function getReleases(user: string, name: string): Promise<Release[]> {
-  const url = `https://api.github.com/repos/${user}/${name}/releases`;
+  const url = `https://www.infracost.io/releases.json`;
 
   const res = await fetch(url);
   const resJson = await res.json()
@@ -260,7 +260,7 @@ function exportEnvVars() {
   if (repoUrl) {
     taskLib.setVariable('INFRACOST_VCS_REPOSITORY_URL', repoUrl);
   }
-  
+
   const logLevel = taskLib.getVariable('System.Debug') === 'true' ? 'debug' : 'info';
   taskLib.setVariable('INFRACOST_LOG_LEVEL', logLevel)
 }

--- a/tasks/InfracostSetup/task.json
+++ b/tasks/InfracostSetup/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 6
+    "Patch": 7
   },
   "instanceNameFormat": "InfracostSetup $(version)",
   "inputs": [

--- a/testdata/multi_project_config_file_comment_golden.md
+++ b/testdata/multi_project_config_file_comment_golden.md
@@ -29,6 +29,7 @@
   </tbody>
 </table>
 
+
 <details>
 <summary><strong>Infracost output</strong></summary>
 

--- a/testdata/multi_project_matrix_merge_comment_golden.md
+++ b/testdata/multi_project_matrix_merge_comment_golden.md
@@ -29,6 +29,7 @@
   </tbody>
 </table>
 
+
 <details>
 <summary><strong>Infracost output</strong></summary>
 

--- a/testdata/multi_workspace_matrix_merge_comment_golden.md
+++ b/testdata/multi_workspace_matrix_merge_comment_golden.md
@@ -29,6 +29,7 @@
   </tbody>
 </table>
 
+
 <details>
 <summary><strong>Infracost output</strong></summary>
 

--- a/testdata/slack_comment_golden.md
+++ b/testdata/slack_comment_golden.md
@@ -29,6 +29,7 @@
   </tbody>
 </table>
 
+
 <details>
 <summary><strong>Infracost output</strong></summary>
 

--- a/testdata/terraform_project_comment_golden.md
+++ b/testdata/terraform_project_comment_golden.md
@@ -29,6 +29,7 @@
   </tbody>
 </table>
 
+
 <details>
 <summary><strong>Infracost output</strong></summary>
 

--- a/testdata/terragrunt_project_comment_golden.md
+++ b/testdata/terragrunt_project_comment_golden.md
@@ -29,6 +29,7 @@
   </tbody>
 </table>
 
+
 <details>
 <summary><strong>Infracost output</strong></summary>
 

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "infracost-tasks",
   "name": "Infracost Tasks",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "publisher": "Infracost",
   "targets": [
     {


### PR DESCRIPTION
Fixes #73 by using the cached release info at https://www.infracost.io/releases.json