### PR TITLE
chore: bump version to 2.1.1

### DIFF
--- a/tasks/InfracostSetup/task.json
+++ b/tasks/InfracostSetup/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 0
+    "Patch": 1
   },
   "instanceNameFormat": "InfracostSetup $(version)",
   "inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "infracost-tasks",
   "name": "Infracost Tasks",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "publisher": "Infracost",
   "targets": [
     {


### PR DESCRIPTION
Patch release covering #97 (dependabot security alerts, version pinning, mocha v11 test fix) and #98 (lockfile vulnerability patches).

Terraform Cloud/Enterprise and Terragrunt pipeline tests have pre-existing failures unrelated to this PR (expired TFC token and empty terragrunt plan output).